### PR TITLE
Fix stacked area chart order issue

### DIFF
--- a/Sources/Charts/Chart/Styles/Area/StackedAreaChartStyle.swift
+++ b/Sources/Charts/Chart/Styles/Area/StackedAreaChartStyle.swift
@@ -8,7 +8,7 @@ public struct StackedAreaChartStyle: ChartStyle {
     public func makeBody(configuration: Self.Configuration) -> some View {
         ZStack {
             ForEach(Array(configuration.dataMatrix.transpose().stacked().enumerated()), id: \.self.offset) { enumeratedData in
-                self.colors.prefix(configuration.dataMatrix.count)[enumeratedData.offset % self.colors.count].clipShape(
+                colors[enumeratedData.offset % colors.count].clipShape(
                     AreaChart(
                         unitData: enumeratedData.element,
                         lineType: self.lineType

--- a/Sources/Charts/Chart/Styles/Area/StackedAreaChartStyle.swift
+++ b/Sources/Charts/Chart/Styles/Area/StackedAreaChartStyle.swift
@@ -7,13 +7,14 @@ public struct StackedAreaChartStyle: ChartStyle {
     
     public func makeBody(configuration: Self.Configuration) -> some View {
         ZStack {
-            ForEach(Array(configuration.dataMatrix.flipDirection().stacked().reversed().enumerated()), id: \.self.offset) { enumeratedData in
-                self.colors.prefix(configuration.dataMatrix.count).reversed()[enumeratedData.offset % self.colors.count].clipShape(
+            ForEach(Array(configuration.dataMatrix.transpose().stacked().enumerated()), id: \.self.offset) { enumeratedData in
+                self.colors.prefix(configuration.dataMatrix.count)[enumeratedData.offset % self.colors.count].clipShape(
                     AreaChart(
                         unitData: enumeratedData.element,
                         lineType: self.lineType
                     )
                 )
+                .zIndex(-Double(enumeratedData.offset))
             }
         }
         .drawingGroup()
@@ -38,14 +39,14 @@ extension Collection where Element == [CGFloat] {
 }
 
 extension Array where Element == [CGFloat] {
-    func flipDirection() -> [[CGFloat]] {
+    func transpose() -> [[CGFloat]] {
         let columnsCount = self.first?.count ?? 0
         let rowCount = self.count
         
         return (0..<columnsCount).map { columnIndex in
             (0..<rowCount).map { rowIndex in
                 return self[rowIndex][columnIndex]
-            }.reversed()
+            }
         }
     }
 }


### PR DESCRIPTION
There may be some issues in the `StackedAreaChartStyle`. I've tried the code below:

```swift
struct StackedAreaChartDemo: View {
    private let matrixData: [[CGFloat]] = [[0.0, 0.2, 0.3], [0.3, 0.3, 0.3], [0.6, 0.2, 0.0]]
    
    var body: some View {
        Chart(data: matrixData)
            .chartStyle(
                StackedAreaChartStyle(.quadCurve, colors: [.yellow, .orange, .red])
            )
            .background(
                Color.gray.opacity(0.1)
                    .overlay(
                        GridPattern(verticalLines: matrixData.count)
                            .inset(by: 1)
                            .stroke(Color.red.opacity(0.2), style: .init(lineWidth: 1, lineCap: .round))
                    )
            )
            .cornerRadius(16)
            .padding()
    }
}
```

Which returns:

<img width="369" alt="截屏2021-08-23 下午4 29 13" src="https://user-images.githubusercontent.com/1070225/130416883-b836425d-f986-4ebc-9f47-b4f73b23ba5a.png">

I think it is a horizontal flipped of the correct chart:

<img width="369" alt="截屏2021-08-23 下午4 28 33" src="https://user-images.githubusercontent.com/1070225/130417102-8152b261-e40e-44c6-962e-3b30e2196ccb.png">

I've checked out the implementation of `StackedAreaChartStyle`. There is no need to do multiple reversed operations to the original data. Simply transpose the data matrix will do the job. In the end, use the zIndex to put layers into correct order.


